### PR TITLE
Upgrade to latest build plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,4 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.1.5"
-    }
+plugins {
+    id "io.micronaut.build.internal.docs"
+    id "io.micronaut.build.internal.dependency-updates"
 }
-
-subprojects { Project subproject ->
-    def path = subproject.getPath()
-    if (!path.contains("docs") && !path.contains('test') || path.contains('jms-test')) {
-        group 'io.micronaut.jms'
-        apply plugin: 'io.micronaut.build.internal.publishing'
-        apply plugin: 'io.micronaut.build.internal.common'
-        apply plugin: 'io.micronaut.build.internal.dependency-updates'
-    }
-}
-
-apply plugin: 'io.micronaut.build.internal.docs'
-apply plugin: 'io.micronaut.build.internal.dependency-updates'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.jms-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.jms-module.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id "io.micronaut.build.internal.module"
+}
+
+group = 'io.micronaut.jms'

--- a/jms-activemq-artemis/build.gradle
+++ b/jms-activemq-artemis/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'io.micronaut.build.internal.jms-module'
+}
+
 dependencies {
     api project(':jms-core')
     api ('org.apache.activemq:artemis-jms-client:2.19.0') {

--- a/jms-activemq-classic/build.gradle
+++ b/jms-activemq-classic/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'io.micronaut.build.internal.jms-module'
+}
+
 dependencies {
     api project(':jms-core')
     api 'org.apache.activemq:activemq-client:5.16.3'

--- a/jms-core/build.gradle
+++ b/jms-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'io.micronaut.build.internal.jms-module'
+}
+
 dependencies {
     annotationProcessor 'io.micronaut:micronaut-inject-java'
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"

--- a/jms-sqs/build.gradle
+++ b/jms-sqs/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'io.micronaut.build.internal.jms-module'
+}
+
 dependencies {
     api project(':jms-core')
     api 'com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8'

--- a/jms-test/build.gradle
+++ b/jms-test/build.gradle
@@ -1,3 +1,5 @@
+pluginManager.apply(io.micronaut.build.MicronautBuildCommonPlugin)
+
 dependencies {
     api project(':jms-core')
     api 'io.micronaut:micronaut-runtime'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,16 @@
 pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
     plugins {
         id 'io.micronaut.application' version getProperty("micronautGradlePluginVersion")
         id 'io.micronaut.library' version getProperty("micronautGradlePluginVersion")
     }
+}
+
+plugins {
+    id("io.micronaut.build.shared.settings") version "4.2.6"
 }
 
 rootProject.name = 'jms'


### PR DESCRIPTION
This seems to work from my tests:

    ./gradlew publishAllPublicationsToBuildRepository

generates a `build/repo` which has all modules that I think should be published (please check).

    ./gradlew docs

generates the appropriate docs

and

     ./gradlew check

passes