### PR TITLE
Resolving issues with incompatible class file versions

### DIFF
--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 micronaut {
-    testRuntime 'kotest'
+    testRuntime 'kotest5'
 }
 
 mainClassName = 'io.micronaut.jms.docs.ApplicationKt'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-activemq = '5.17.2'
+activemq = '5.16.3'
 amazon-sqs-messaging = '1.1.0'
-artemis-client = '2.27.0'
+artemis-client = '2.19.0'
 awaitility = '4.2.0'
 aws-sqs = '1.12.349'
 commons-pool2 = '2.11.1'


### PR DESCRIPTION
- Revert activemq/artemis-client libs minor updates. They are Java 11 and break jdk8 builds with 'class file has wrong version 55.0, should be 52.0' error.
- IncompatibleClassChangeError using `3.toDuration(DurationUnit.SECONDS)` with kotest