### PR TITLE
Introduce BOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ githubCoreBranch=4.0.x
 bomProperty=micronautJmsVersion
 
 org.gradle.caching=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g
 
 apijms=https://docs.oracle.com/javaee/7/api/javax/jms/

--- a/jms-bom/build.gradle
+++ b/jms-bom/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id("io.micronaut.build.internal.bom")
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = providers.provider {
+            def (major, minor, _) = project.version.split("\\.")
+            major.toInteger() >= 3 && minor.toInteger() > 0
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ plugins {
 
 rootProject.name = 'jms-parent'
 
+include 'jms-bom'
 include 'jms-core'
 include 'jms-activemq-classic'
 include 'jms-activemq-artemis'


### PR DESCRIPTION
Once this is merged, we can update `micronaut-platform` to include it instead of the individual libraries.