### PR TITLE
Test failure for jms-sqs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ spotbugs = "4.7.3"
 testcontainers = '1.18.1'
 lombok = '1.18.28'
 
-micronaut-aws-v2 = '3.17.2'
+micronaut-aws-v2 = '4.0.0-M6'
 micronaut-validation = "4.0.0-M9"
 micronaut-gradle-plugin = "4.0.0-M4"
 

--- a/tests/tasks-sqs/src/test/groovy/example/TasksSpec.groovy
+++ b/tests/tasks-sqs/src/test/groovy/example/TasksSpec.groovy
@@ -5,7 +5,6 @@ import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import org.testcontainers.utility.DockerImageName
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -13,7 +12,6 @@ import static example.LocalStackContainer.Service.SQS
 
 class TasksSpec extends Specification {
 
-    @PendingFeature
     void 'should process tasks'() {
         when:
         LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse('localstack/localstack')).withServices(SQS)

--- a/tests/tasks-sqs/src/test/groovy/example/TasksSpec.groovy
+++ b/tests/tasks-sqs/src/test/groovy/example/TasksSpec.groovy
@@ -16,8 +16,13 @@ class TasksSpec extends Specification {
         when:
         LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse('localstack/localstack')).withServices(SQS)
         localstack.start()
-        EmbeddedServer server = ApplicationContext.run(['sqs-url': localstack.getEndpointOverride(SQS).toString(),
-         'sqs-region': localstack.region])
+        EmbeddedServer server = ApplicationContext.run(
+                EmbeddedServer,
+                [
+                        'sqs-url'   : localstack.getEndpointOverride(SQS).toString(),
+                        'sqs-region': localstack.region,
+                ]
+        )
         HttpClient httpClient = server.applicationContext.createBean(HttpClient, server.URL)
         BlockingHttpClient client = httpClient.toBlocking()
 


### PR DESCRIPTION
Failure https://ge.micronaut.io/s/fshrmjxbbaeee

````
Bean definition [io.micronaut.jms.configuration.JMSConnectionFactoryBeanProcessor] could not be loaded: Error processing bean definition [Definition: io.micronaut.jms.sqs.configuration.SqsConfiguration]: Failed to inject value for parameter [builder] of method [sqsJmsConnectionFactory] of class: io.micronaut.jms.sqs.configuration.SqsConfiguration

Message: No bean of type [software.amazon.awssdk.services.sqs.SqsClientBuilder] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
Path Taken: SqsConfiguration.sqsJmsConnectionFactory(SqsConfigurationProperties config,SqsClientBuilder builder) --> SqsConfiguration.sqsJmsConnectionFactory(SqsConfigurationProperties config,[SqsClientBuilder builder])
io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.jms.configuration.JMSConnectionFactoryBeanProcessor] could not be loaded: Error processing bean definition [Definition: io.micronaut.jms.sqs.configuration.SqsConfiguration]: Failed to inject value for parameter [builder] of method [sqsJmsConnectionFactory] of class: io.micronaut.jms.sqs.configuration.SqsConfiguration

Message: No bean of type [software.amazon.awssdk.services.sqs.SqsClientBuilder] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
Path Taken: SqsConfiguration.sqsJmsConnectionFactory(SqsConfigurationProperties config,SqsClientBuilder builder) --> SqsConfiguration.sqsJmsConnectionFactory(SqsConfigurationProperties config,[SqsClientBuilder builder])
	at app//io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1979)
	at app//io.micronaut.cont
```