### PR TITLE
Removed hardcoded version of metadata repo.

### DIFF
--- a/docs-examples/example-java/build.gradle
+++ b/docs-examples/example-java/build.gradle
@@ -12,9 +12,3 @@ micronaut {
 }
 
 mainClassName = 'io.micronaut.jms.docs.Application'
-
-graalvmNative {
-    metadataRepository {
-        version = "0.3.2"
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ spotbugs = "4.7.3"
 testcontainers = '1.18.3'
 micronaut-aws-v2 = '4.0.1'
 micronaut-validation = "4.0.0"
-micronaut-gradle-plugin = "4.0.0"
+micronaut-gradle-plugin = "4.0.3"
 
 micronaut-logging = "1.0.0"
 [libraries]


### PR DESCRIPTION
The latest version which comes via micronaut gradle and native build tool plugins needs to be used.