### PR TITLE
Treat empty message selector as null

### DIFF
--- a/jms-core/src/main/java/io/micronaut/jms/configuration/AbstractJMSListenerMethodProcessor.java
+++ b/jms-core/src/main/java/io/micronaut/jms/configuration/AbstractJMSListenerMethodProcessor.java
@@ -131,7 +131,10 @@ public abstract class AbstractJMSListenerMethodProcessor<T extends Annotation>
         final String destination = destinationAnnotation.getRequiredValue(String.class);
         final int acknowledgeMode = destinationAnnotation.getRequiredValue("acknowledgeMode", Integer.class);
         final boolean transacted = destinationAnnotation.getRequiredValue("transacted", Boolean.class);
-        final Optional<String> messageSelector = destinationAnnotation.get("messageSelector", String.class);
+        Optional<String> messageSelector = destinationAnnotation.get("messageSelector", String.class);
+        if (messageSelector.isPresent() && messageSelector.get().isEmpty()) {
+            messageSelector = Optional.empty();
+        }
 
         final JMSListenerRegistry registry = beanContext
                 .findBean(JMSListenerRegistry.class)


### PR DESCRIPTION
Ref #439 SQS not supporting non-null message selector. 

Probably a better way to solve it, but at least this works for me. 