### PR TITLE
SQS does not support message selector bug fix

### DIFF
--- a/jms-core/src/main/java/io/micronaut/jms/listener/JMSListener.java
+++ b/jms-core/src/main/java/io/micronaut/jms/listener/JMSListener.java
@@ -130,7 +130,7 @@ public class JMSListener {
      */
     public void start() throws JMSException {
         MessageConsumer messageConsumer;
-        if (messageSelector.isPresent()) {
+        if (messageSelector.isPresent() && !messageSelector.get().isEmpty()) {
             messageConsumer = session.createConsumer(lookupDestination(destinationType, destination, session), messageSelector.get());
         } else {
             messageConsumer = session.createConsumer(lookupDestination(destinationType, destination, session));


### PR DESCRIPTION
This commit fixes #439

See also:
- [@Queue#messageSelector()](https://github.com/micronaut-projects/micronaut-jms/blob/v3.1.0/jms-core/src/main/java/io/micronaut/jms/annotations/Queue.java#L134)
- [SQSSession#createConsumer(Destination destination, String messageSelector)](https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/2.0.3/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java#L598)