### PR TITLE
Fix generic type preservation for JMS body deserialization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ commons-pool2 = { module = 'org.apache.commons:commons-pool2', version.ref = 'co
 graal-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graal-svm" }
 jcl-slf4j = { module = 'org.slf4j:jcl-over-slf4j', version.ref = 'jcl-slf4j' }
 jsr305 = {group = "com.google.code.findbugs", name = "jsr305", version.ref = "jsr305" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 javax-json-api = { module = 'javax.json:javax.json-api', version.ref = 'json-api' }
 

--- a/jms-core/build.gradle.kts
+++ b/jms-core/build.gradle.kts
@@ -9,4 +9,8 @@ dependencies {
     api(libs.managed.jakarta.jms.api)
     api(libs.commons.pool2)
     implementation(mn.micronaut.jackson.databind)
+    testImplementation(platform(mnTest.micronaut.test.bom))
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/jms-core/src/main/java/io/micronaut/jms/bind/DefaultBodyArgumentBinder.java
+++ b/jms-core/src/main/java/io/micronaut/jms/bind/DefaultBodyArgumentBinder.java
@@ -46,7 +46,7 @@ public class DefaultBodyArgumentBinder extends AbstractJmsArgumentBinder<Message
 
     @Override
     public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Message source) {
-        return () -> Optional.of(deserializer.deserialize(source, context.getArgument().getType()));
+        return () -> Optional.of(deserializer.deserialize(source, context.getArgument()));
     }
 
     @Override

--- a/jms-core/src/main/java/io/micronaut/jms/bind/MessageBodyHeaderArgumentBinder.java
+++ b/jms-core/src/main/java/io/micronaut/jms/bind/MessageBodyHeaderArgumentBinder.java
@@ -46,7 +46,7 @@ public class MessageBodyHeaderArgumentBinder extends AbstractJmsArgumentBinder<M
 
     @Override
     public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Message source) {
-        return () -> Optional.of(deserializer.deserialize(source, context.getArgument().getType()));
+        return () -> Optional.of(deserializer.deserialize(source, context.getArgument()));
     }
 
     @Override
@@ -54,4 +54,3 @@ public class MessageBodyHeaderArgumentBinder extends AbstractJmsArgumentBinder<M
         return MessageBody.class;
     }
 }
-

--- a/jms-core/src/main/java/io/micronaut/jms/serdes/DefaultSerializerDeserializer.java
+++ b/jms-core/src/main/java/io/micronaut/jms/serdes/DefaultSerializerDeserializer.java
@@ -128,7 +128,8 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
         if (clazz.isInstance(body)) {
             return clazz.cast(body);
         }
-        return (T) body;
+        throw new ClassCastException("Cannot deserialize ObjectMessage body to type " + clazz.getName()
+            + "; actual body type is " + (body == null ? "null" : body.getClass().getName()));
     }
 
     @Override

--- a/jms-core/src/main/java/io/micronaut/jms/serdes/DefaultSerializerDeserializer.java
+++ b/jms-core/src/main/java/io/micronaut/jms/serdes/DefaultSerializerDeserializer.java
@@ -58,6 +58,11 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
 
     @Override
     public <T> T deserialize(Message message, Class<T> clazz) {
+        return deserialize(message, Argument.of(clazz));
+    }
+
+    @Override
+    public <T> T deserialize(Message message, Argument<T> argument) {
         if (message == null) {
             return null;
         }
@@ -67,11 +72,11 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
                 case MAP:
                     return deserializeMap((MapMessage) message);
                 case TEXT:
-                    return deserializeText((TextMessage) message, clazz);
+                    return deserializeText((TextMessage) message, argument);
                 case BYTES:
                     return deserializeBytes((BytesMessage) message);
                 case OBJECT:
-                    return deserializeObject((ObjectMessage) message, clazz);
+                    return deserializeObject((ObjectMessage) message, argument);
                 default:
                     throw new IllegalArgumentException("No known deserialization of message " + message);
             }
@@ -93,11 +98,12 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
 
     @SuppressWarnings("unchecked")
     private <T> T deserializeText(final TextMessage message,
-                                  final Class<T> clazz) throws JMSException, IOException {
+                                  final Argument<T> argument) throws JMSException, IOException {
+        Class<T> clazz = argument.getType();
         if (clazz.isAssignableFrom(String.class)) {
             return (T) message.getText();
         }
-        return objectMapperSupplier.get().readValue(message.getText(), Argument.of(clazz));
+        return objectMapperSupplier.get().readValue(message.getText(), argument);
     }
 
     private <T> T deserializeBytes(final BytesMessage message) throws JMSException {
@@ -109,7 +115,8 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
 
     @SuppressWarnings("unchecked")
     private <T> T deserializeObject(final ObjectMessage message,
-                                    final Class<T> clazz) throws JMSException, IOException {
+                                    final Argument<T> argument) throws JMSException, IOException {
+        Class<T> clazz = argument.getType();
 
         Serializable body = message.getObject();
         if (body instanceof String) {
@@ -118,7 +125,10 @@ public final class DefaultSerializerDeserializer implements Serializer, Deserial
                 return (T) body;
             }
         }
-        return (T) message.getObject();
+        if (clazz.isInstance(body)) {
+            return clazz.cast(body);
+        }
+        return (T) body;
     }
 
     @Override

--- a/jms-core/src/main/java/io/micronaut/jms/serdes/Deserializer.java
+++ b/jms-core/src/main/java/io/micronaut/jms/serdes/Deserializer.java
@@ -44,6 +44,11 @@ public interface Deserializer {
      * @param argument the argument
      * @param <T> the type
      * @return the extracted message body as an instance of the specified type
+     *
+     * The default implementation delegates to {@link #deserialize(Message, Class)} and only uses
+     * {@link Argument#getType()}, so it does not preserve type variables. Implementers should
+     * override this method to support generic-aware deserialization.
+     *
      * @since 5.0.0
      */
     default <T> T deserialize(Message message, Argument<T> argument) {

--- a/jms-core/src/main/java/io/micronaut/jms/serdes/Deserializer.java
+++ b/jms-core/src/main/java/io/micronaut/jms/serdes/Deserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jms.serdes;
 
+import io.micronaut.core.type.Argument;
 import jakarta.jms.Message;
 
 /**
@@ -33,7 +34,20 @@ public interface Deserializer {
      * @return the extracted message body as an instance of a sensible type
      */
     default Object deserialize(Message message) {
-        return deserialize(message, Object.class);
+        return deserialize(message, Argument.of(Object.class));
+    }
+
+    /**
+     * Extract the body of the message into the specified type.
+     *
+     * @param message the message
+     * @param argument the argument
+     * @param <T> the type
+     * @return the extracted message body as an instance of the specified type
+     * @since 5.0.0
+     */
+    default <T> T deserialize(Message message, Argument<T> argument) {
+        return deserialize(message, argument.getType());
     }
 
     /**

--- a/jms-core/src/test/java/io/micronaut/jms/bind/MessageBodyArgumentBindersTest.java
+++ b/jms-core/src/test/java/io/micronaut/jms/bind/MessageBodyArgumentBindersTest.java
@@ -75,6 +75,7 @@ class MessageBodyArgumentBindersTest {
         private final List<String> value = List.of("value");
 
         @Override
+        @SuppressWarnings("unchecked")
         public <T> T deserialize(Message message, Argument<T> argument) {
             capturedArgument.set(argument);
             return (T) value;

--- a/jms-core/src/test/java/io/micronaut/jms/bind/MessageBodyArgumentBindersTest.java
+++ b/jms-core/src/test/java/io/micronaut/jms/bind/MessageBodyArgumentBindersTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jms.bind;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
+import io.micronaut.jms.serdes.Deserializer;
+import jakarta.jms.Message;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class MessageBodyArgumentBindersTest {
+
+    @Test
+    void defaultBodyBinderPreservesArgumentTypeVariables() {
+        CapturingDeserializer deserializer = new CapturingDeserializer();
+        assertBinderPreservesArgumentTypeVariables(new DefaultBodyArgumentBinder(ConversionService.SHARED, deserializer), deserializer);
+    }
+
+    @Test
+    void messageBodyHeaderBinderPreservesArgumentTypeVariables() {
+        CapturingDeserializer deserializer = new CapturingDeserializer();
+        assertBinderPreservesArgumentTypeVariables(new MessageBodyHeaderArgumentBinder(ConversionService.SHARED, deserializer), deserializer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertBinderPreservesArgumentTypeVariables(AbstractJmsArgumentBinder<?> binder,
+                                                                   CapturingDeserializer deserializer) {
+        Argument<List<String>> argument = Argument.listOf(String.class);
+        ArgumentConversionContext<Object> context = ConversionContext.of((Argument<Object>) (Argument<?>) argument);
+        Object bound = binder.bind(context, message()).get();
+
+        assertSame(deserializer.value, bound);
+        assertSame(argument, deserializer.capturedArgument.get());
+        assertEquals(String.class, deserializer.capturedArgument.get().getFirstTypeVariable().orElseThrow().getType());
+    }
+
+    private static Message message() {
+        return (Message) Proxy.newProxyInstance(
+            Message.class.getClassLoader(),
+            new Class<?>[]{Message.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "toString" -> "MessageBodyArgumentBindersTestMessage";
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                default -> null;
+            }
+        );
+    }
+
+    private static final class CapturingDeserializer implements Deserializer {
+
+        private final AtomicReference<Argument<?>> capturedArgument = new AtomicReference<>();
+        private final List<String> value = List.of("value");
+
+        @Override
+        public <T> T deserialize(Message message, Argument<T> argument) {
+            capturedArgument.set(argument);
+            return (T) value;
+        }
+
+        @Override
+        public <T> T deserialize(Message message, Class<T> clazz) {
+            throw new UnsupportedOperationException("Class-based deserialization should not be used");
+        }
+    }
+}

--- a/jms-core/src/test/java/io/micronaut/jms/serdes/DefaultSerializerDeserializerTest.java
+++ b/jms-core/src/test/java/io/micronaut/jms/serdes/DefaultSerializerDeserializerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jms.serdes;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.type.Argument;
+import jakarta.jms.TextMessage;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DefaultSerializerDeserializerTest {
+
+    @Test
+    void deserializeTextPreservesListElementType() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            DefaultSerializerDeserializer deserializer = context.getBean(DefaultSerializerDeserializer.class);
+
+            List<String> values = deserializer.deserialize(textMessage("[\"alpha\",\"beta\"]"), Argument.listOf(String.class));
+
+            assertEquals(List.of("alpha", "beta"), values);
+        }
+    }
+
+    private static TextMessage textMessage(String text) {
+        return (TextMessage) Proxy.newProxyInstance(
+            TextMessage.class.getClassLoader(),
+            new Class<?>[]{TextMessage.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getText" -> text;
+                case "toString" -> "TextMessage[" + text + "]";
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                default -> null;
+            }
+        );
+    }
+}

--- a/jms-core/src/test/java/io/micronaut/jms/serdes/DefaultSerializerDeserializerTest.java
+++ b/jms-core/src/test/java/io/micronaut/jms/serdes/DefaultSerializerDeserializerTest.java
@@ -17,6 +17,8 @@ package io.micronaut.jms.serdes;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.type.Argument;
+import io.micronaut.messaging.exceptions.MessageListenerException;
+import jakarta.jms.ObjectMessage;
 import jakarta.jms.TextMessage;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ import java.lang.reflect.Proxy;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultSerializerDeserializerTest {
 
@@ -38,6 +41,21 @@ class DefaultSerializerDeserializerTest {
         }
     }
 
+    @Test
+    void deserializeObjectFailsFastForIncompatibleBodyType() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            DefaultSerializerDeserializer deserializer = context.getBean(DefaultSerializerDeserializer.class);
+
+            MessageListenerException exception = assertThrows(MessageListenerException.class,
+                () -> deserializer.deserialize(objectMessage("value"), Integer.class));
+
+            assertEquals("Problem deserializing message ObjectMessage[value]", exception.getMessage());
+            assertEquals(ClassCastException.class, exception.getCause().getClass());
+            assertEquals("Cannot deserialize ObjectMessage body to type java.lang.Integer; actual body type is java.lang.String",
+                exception.getCause().getMessage());
+        }
+    }
+
     private static TextMessage textMessage(String text) {
         return (TextMessage) Proxy.newProxyInstance(
             TextMessage.class.getClassLoader(),
@@ -45,6 +63,20 @@ class DefaultSerializerDeserializerTest {
             (proxy, method, args) -> switch (method.getName()) {
                 case "getText" -> text;
                 case "toString" -> "TextMessage[" + text + "]";
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                default -> null;
+            }
+        );
+    }
+
+    private static ObjectMessage objectMessage(Object value) {
+        return (ObjectMessage) Proxy.newProxyInstance(
+            ObjectMessage.class.getClassLoader(),
+            new Class<?>[]{ObjectMessage.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getObject" -> value;
+                case "toString" -> "ObjectMessage[" + value + "]";
                 case "equals" -> proxy == args[0];
                 case "hashCode" -> System.identityHashCode(proxy);
                 default -> null;


### PR DESCRIPTION
## Summary
- preserve full Micronaut `Argument` metadata when binding JMS `@MessageBody` arguments
- add `Argument<T>` deserialization support so serde can retain list element types
- add focused regression tests for binders and text message deserialization

## Verification
- `./gradlew :micronaut-jms-core:test --tests 'io.micronaut.jms.bind.MessageBodyArgumentBindersTest' --tests 'io.micronaut.jms.serdes.DefaultSerializerDeserializerTest'`

Resolves #744