### PR TITLE
Start 5.2.x at 5.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.1.1-SNAPSHOT
+projectVersion=5.2.0-SNAPSHOT
 projectGroup=io.micronaut.jms
 
 title=Micronaut JMS

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 managed-jakarta-jms-api = '3.1.0'
 managed-activemq-jakarta = '6.2.7'
 managed-artemis-jakarta-client = '2.55.0'
-micronaut = "5.1.7"
+micronaut = "5.2.0"
 micronaut-platform = "5.0.4"
 micronaut-test = "5.1.0"
 micronaut-logging = "2.1.0"


### PR DESCRIPTION
Starts the new minor branch `5.2.x` (created from `5.1.x`) at `5.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `5.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

Switching the default and Renovate base branch to `5.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)